### PR TITLE
feat: Update Memoize class to support custom JSON parsing and stringfying

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ speeding up overall application responsiveness and reducing server load.
   consistency across asynchronous operations.
 - **Adaptive Cache Key Generation**: Features customizable cache key generation strategies to accommodate functions
   where the order of arguments is irrelevant to the output.
+- **Custom Serialization Support**: Provides options for custom serializers and deserializers, making it easy to handle
+  complex data types like BigInt, Date, or custom objects that aren't natively supported by JSON.
 - **Batch Execution Support**: Enhances performance for batch operations through its multi-execution capabilities,
   reducing processing time and resource consumption.
 - **Robust Error Handling**: Implements error management strategies to maintain application stability even when the
@@ -37,7 +39,7 @@ Below is a simple example demonstrating how to use **Memoose-js** to memoize a f
 arguments. This example uses an in-memory cache provider to store the results with a TTL (time-to-live) of 10 seconds.
 
 ```typescript
-import { Memoize, MemoryCacheProvider } from 'memoose-js';
+import { Memoize, MemoryCacheProvider, RedisCacheProvider, SerializationOptions } from 'memoose-js';
 
 // Define a function to be memoized
 function computeSum(...numbers) {
@@ -64,4 +66,57 @@ async function testMemoization() {
 }
 
 testMemoization();
+```
+
+### Advanced Example: Custom Serialization with BigInt Support
+
+When working with databases or other systems that use BigInt values, standard JSON serialization fails because BigInt isn't natively supported in JSON. Memoose-js solves this with custom serialization options:
+
+```typescript
+import { Memoize, RedisCacheProvider, SerializationOptions } from 'memoose-js';
+
+// Custom serialization options for handling BigInt values
+const bigIntSerializationOptions: SerializationOptions = {
+  serializer: (key, value) => {
+    // Convert BigInt to a specially formatted string
+    if (typeof value === 'bigint') {
+      return `__BIGINT__${value.toString()}`;
+    }
+    return value;
+  },
+  deserializer: (key, value) => {
+    // Convert the formatted string back to BigInt
+    if (typeof value === 'string' && value.startsWith('__BIGINT__')) {
+      return BigInt(value.substring(10));
+    }
+    return value;
+  }
+};
+
+// Create Redis provider with custom serialization
+const redisProvider = new RedisCacheProvider(
+  "myapp", 
+  { host: "localhost", port: 6379 }, 
+  true, 
+  bigIntSerializationOptions
+);
+
+// Function that works with database records
+async function getUserById(id) {
+  // Normally this would fetch from a database
+  return {
+    id: BigInt(id),
+    name: "User " + id,
+    created: BigInt(Date.now())
+  };
+}
+
+// Memoize the function with Redis cache
+const memoizedGetUser = new Memoize(getUserById, 300, {
+  cacheProvider: redisProvider
+});
+
+// Now you can safely work with BigInt values in your cached results
+const user = await memoizedGetUser.call(123456789012345);
+console.log(user.id); // BigInt value preserved
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "ts-node sample"
   },
   "dependencies": {
+    "lodash": "^4.17.21",
     "object-hash": "^3.0.0"
   },
   "optionalDependencies": {
@@ -23,8 +24,10 @@
     "mongoose": "^8.4.4"
   },
   "devDependencies": {
-    "@types/object-hash": "^3.0.6",
+    "@types/lodash": "^4.17.16",
     "@types/node": "^20.14.9",
+    "@types/object-hash": "^3.0.6",
+    "ts-node": "^10.9.2",
     "typescript": "^5.5.2"
   },
   "keywords": [

--- a/src/Memoize.ts
+++ b/src/Memoize.ts
@@ -1,5 +1,5 @@
 import {CacheKeyGenerator as CacheKeyGenerator} from "./CacheKeyGenerator";
-import {CacheKey, CacheProvider, Pipeline, TReplacerFunction, TReviverFunction, TTL} from "./adapters/base";
+import {CacheKey, CacheProvider, Pipeline, TSerializer, TDeserializer, TTL} from "./adapters/base";
 import {MemoryCacheProvider, RedisCacheProvider} from "./adapters";
 
 export const stats: any = {redis: {}, memory: {}};
@@ -18,8 +18,8 @@ export class Memoize<Args extends Array<any> = any[], ReturnType = any> {
     private readonly functionName: string;
     private readonly argsOrderVain: boolean;
     private readonly storeAsObj: boolean;
-    private readonly jsonParseReviver: TReviverFunction | undefined
-    private readonly jsonStringifyReplacer: TReplacerFunction | undefined
+    private readonly serializer: TSerializer | undefined;
+    private readonly deserializer: TDeserializer | undefined;
     private func: Function;
     private cacheKeyGenerator: CacheKeyGenerator;
     private readonly name: string;
@@ -53,8 +53,8 @@ export class Memoize<Args extends Array<any> = any[], ReturnType = any> {
         this.cacheKeyGenerator = options.cacheKeyGenerator || new CacheKeyGenerator(this.functionName, this.argsOrderVain);
         this.cache = options.cacheProvider || new MemoryCacheProvider();
         this.storeAsObj = this.cache.storesAsObj;
-        this.jsonParseReviver = this.cache.jsonParseReviver
-        this.jsonStringifyReplacer = this.cache.jsonStringifyReplacer
+        this.serializer = this.cache.serializationOptions.serializer;
+        this.deserializer = this.cache.serializationOptions.deserializer;
         this.name = this.cache.name();
 
         //add chunking for default function if needed
@@ -74,14 +74,14 @@ export class Memoize<Args extends Array<any> = any[], ReturnType = any> {
     }
 
     private processedObjFromCache(this: Memoize<Args, ReturnType>, obj: CachedItem): Promise<ReturnType> {
-        function processStr(obj: string, jsonParseReviver?: TReviverFunction) {
+        function processStr(obj: string, deserializer?: TDeserializer) {
             if (obj.indexOf('-undefined-') === 0)
                 return undefined
 
             if (obj.indexOf('-null-') === 0)
                 return null
 
-            return JSON.parse(obj, jsonParseReviver)
+            return JSON.parse(obj, deserializer)
         }
 
         if (this.storeAsObj && !isString(obj))
@@ -91,16 +91,16 @@ export class Memoize<Args extends Array<any> = any[], ReturnType = any> {
             throw new Error("stored as string but got obj from cache?")
 
         if (obj.indexOf('-reject-') === 0)
-            return Promise.reject(processStr(obj.substr('-reject-'.length), this.jsonParseReviver))
+            return Promise.reject(processStr(obj.substr('-reject-'.length), this.deserializer))
         else
-            return Promise.resolve(processStr(obj, this.jsonParseReviver))
+            return Promise.resolve(processStr(obj, this.deserializer))
     }
 
     private processObjForCache(this: Memoize<Args, ReturnType>, obj: any, rejection: boolean = false) {
         if (this.storeAsObj) {
             return {data: obj, reject: rejection}
         } else {
-            let resp_val = JSON.stringify(obj, this.jsonStringifyReplacer);
+            let resp_val = JSON.stringify(obj, this.serializer);
             if (resp_val === undefined) resp_val = '-undefined-';
             if (resp_val === null) resp_val = '-null-';
             if (rejection) resp_val = `-reject-${resp_val}`;

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -24,13 +24,13 @@ export interface SerializationOptions {
 }
 
 export interface CacheProvider<T> extends CacheProviderCore<T> {
-  name(): string;
+    name(): string;
 
-  pipeline(): Pipeline<T>;
+    pipeline(): Pipeline<T>;
 
-  get storesAsObj(): boolean
+    get storesAsObj(): boolean
 
-  get serializationOptions(): SerializationOptions
+    get serializationOptions(): SerializationOptions
 }
 
 export interface Pipeline<T> {

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -2,17 +2,17 @@ export type CacheKey = string
 export type TTL = number
 
 interface CacheProviderCore<T> {
-  get(key: CacheKey): Promise<T | null>;
+    get(key: CacheKey): Promise<T | null>;
 
-  mget(...key: CacheKey[]): Promise<(T | null)[]>
+    mget(...key: CacheKey[]): Promise<(T | null)[]>
 
-  mset(...key: [CacheKey, T][]): Promise<"OK" | null>
+    mset(...key: [CacheKey, T][]): Promise<"OK" | null>
 
-  set(key: CacheKey, data: T, ttl?: TTL): Promise<"OK" | null>;
+    set(key: CacheKey, data: T, ttl?: TTL): Promise<"OK" | null>;
 
-  del(...key: CacheKey[]): Promise<number>;
+    del(...key: CacheKey[]): Promise<number>;
 
-  expire(key: CacheKey, new_ttl_from_now: TTL): Promise<0 | 1>;
+    expire(key: CacheKey, new_ttl_from_now: TTL): Promise<0 | 1>;
 }
 
 export type TReplacerFunction = (key: string, value: any) => string;
@@ -30,14 +30,14 @@ export interface CacheProvider<T> extends CacheProviderCore<T> {
 }
 
 export interface Pipeline<T> {
-  get(key: CacheKey): Pipeline<T>;
+    get(key: CacheKey): Pipeline<T>;
 
-  set(key: CacheKey, data: T, ttl?: number): Pipeline<T>;
+    set(key: CacheKey, data: T, ttl?: number): Pipeline<T>;
 
-  del(key: CacheKey): Pipeline<T>;
+    del(key: CacheKey): Pipeline<T>;
 
-  expire(key: CacheKey, new_ttl_from_now: number): Pipeline<T>;
+    expire(key: CacheKey, new_ttl_from_now: number): Pipeline<T>;
 
-  exec(): Promise<any[]>;
+    exec(): Promise<any[]>;
 }
 

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -15,8 +15,13 @@ interface CacheProviderCore<T> {
     expire(key: CacheKey, new_ttl_from_now: TTL): Promise<0 | 1>;
 }
 
-export type TReplacerFunction = (key: string, value: any) => string;
-export type TReviverFunction = (key: string, value: any) => any;
+export type TSerializer = (key: string, value: any) => string;
+export type TDeserializer = (key: string, value: any) => any;
+
+export interface SerializationOptions {
+  serializer?: TSerializer;
+  deserializer?: TDeserializer;
+}
 
 export interface CacheProvider<T> extends CacheProviderCore<T> {
   name(): string;
@@ -25,8 +30,7 @@ export interface CacheProvider<T> extends CacheProviderCore<T> {
 
   get storesAsObj(): boolean
 
-  get jsonStringifyReplacer(): TReplacerFunction | undefined;
-  get jsonParseReviver(): TReviverFunction | undefined;
+  get serializationOptions(): SerializationOptions
 }
 
 export interface Pipeline<T> {

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -2,36 +2,42 @@ export type CacheKey = string
 export type TTL = number
 
 interface CacheProviderCore<T> {
-    get(key: CacheKey): Promise<T | null>;
+  get(key: CacheKey): Promise<T | null>;
 
-    mget(...key: CacheKey[]): Promise<(T | null)[]>
+  mget(...key: CacheKey[]): Promise<(T | null)[]>
 
-    mset(...key: [CacheKey, T][]): Promise<"OK" | null>
+  mset(...key: [CacheKey, T][]): Promise<"OK" | null>
 
-    set(key: CacheKey, data: T, ttl?: TTL): Promise<"OK" | null>;
+  set(key: CacheKey, data: T, ttl?: TTL): Promise<"OK" | null>;
 
-    del(...key: CacheKey[]): Promise<number>;
+  del(...key: CacheKey[]): Promise<number>;
 
-    expire(key: CacheKey, new_ttl_from_now: TTL): Promise<0 | 1>;
+  expire(key: CacheKey, new_ttl_from_now: TTL): Promise<0 | 1>;
 }
 
+export type TReplacerFunction = (key: string, value: any) => string;
+export type TReviverFunction = (key: string, value: any) => any;
+
 export interface CacheProvider<T> extends CacheProviderCore<T> {
-    name(): string;
+  name(): string;
 
-    pipeline(): Pipeline<T>;
+  pipeline(): Pipeline<T>;
 
-    get storesAsObj(): boolean
+  get storesAsObj(): boolean
+
+  get jsonStringifyReplacer(): TReplacerFunction | undefined;
+  get jsonParseReviver(): TReviverFunction | undefined;
 }
 
 export interface Pipeline<T> {
-    get(key: CacheKey): Pipeline<T>;
+  get(key: CacheKey): Pipeline<T>;
 
-    set(key: CacheKey, data: T, ttl?: number): Pipeline<T>;
+  set(key: CacheKey, data: T, ttl?: number): Pipeline<T>;
 
-    del(key: CacheKey): Pipeline<T>;
+  del(key: CacheKey): Pipeline<T>;
 
-    expire(key: CacheKey, new_ttl_from_now: number): Pipeline<T>;
+  expire(key: CacheKey, new_ttl_from_now: number): Pipeline<T>;
 
-    exec(): Promise<any[]>;
+  exec(): Promise<any[]>;
 }
 

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,7 +1,19 @@
 import {RedisCacheProvider} from "./redis";
 import {MemoryCacheProvider} from "./memory"
-import {Pipeline, CacheProvider as BaseCacheProvider} from "./base"
+import {
+    Pipeline, 
+    CacheProvider as BaseCacheProvider, 
+    SerializationOptions,
+    TSerializer,
+    TDeserializer
+} from "./base"
 
 
-export {Pipeline, BaseCacheProvider}
+export {
+    Pipeline, 
+    BaseCacheProvider,
+    SerializationOptions,
+    TSerializer,
+    TDeserializer
+}
 export {RedisCacheProvider, MemoryCacheProvider}

--- a/src/adapters/memory.ts
+++ b/src/adapters/memory.ts
@@ -1,4 +1,4 @@
-import {CacheKey, CacheProvider, Pipeline} from "./base";
+import {CacheKey, CacheProvider, Pipeline, SerializationOptions} from "./base";
 import {setInterval} from "timers";
 
 
@@ -19,9 +19,13 @@ class CacheObject {
 export class MemoryCacheProvider implements CacheProvider<CacheInternalObj> {
     private readonly store: Record<string, CacheObject>;
     readonly storesAsObj: boolean = true
-    // Note: science this is a memory cache stores directly Objects, we don't need to worry about serialization/de-serialization
-    readonly jsonParseReviver = undefined
-    readonly jsonStringifyReplacer = undefined 
+    // Note: since this is a memory cache that stores objects directly, 
+    // we don't need to worry about serialization/deserialization
+    private readonly _serializationOptions: SerializationOptions = {}
+    
+    get serializationOptions(): SerializationOptions {
+        return this._serializationOptions;
+    }
 
     constructor() {
         this.store = {};

--- a/src/adapters/memory.ts
+++ b/src/adapters/memory.ts
@@ -19,6 +19,9 @@ class CacheObject {
 export class MemoryCacheProvider implements CacheProvider<CacheInternalObj> {
     private readonly store: Record<string, CacheObject>;
     readonly storesAsObj: boolean = true
+    // Note: science this is a memory cache stores directly Objects, we don't need to worry about serialization/de-serialization
+    readonly jsonParseReviver = undefined
+    readonly jsonStringifyReplacer = undefined 
 
     constructor() {
         this.store = {};

--- a/src/adapters/redis.ts
+++ b/src/adapters/redis.ts
@@ -1,5 +1,5 @@
 import IORedis, {Redis, RedisOptions} from "ioredis";
-import {CacheKey, CacheProvider} from "./base";
+import { CacheKey, CacheProvider, TReplacerFunction, TReviverFunction } from "./base";
 
 export class RedisCacheProvider implements CacheProvider<string> {
 
@@ -8,18 +8,22 @@ export class RedisCacheProvider implements CacheProvider<string> {
     }
 
     readonly storesAsObj: boolean = false
+    readonly jsonParseReviver: TReviverFunction | undefined
+    readonly jsonStringifyReplacer: TReplacerFunction | undefined
 
     private readonly client_client: Redis;
     private readonly connected_promise: any;
     private readonly connect: boolean;
 
-    constructor(name: string, options: RedisOptions, connect: boolean = true) {
+    constructor(name: string, options: RedisOptions, connect: boolean = true, jsonParseReviver?: TReviverFunction, jsonStringifyReplacer?: TReplacerFunction) {
         this.client_client = new IORedis(options);
         this.connect = connect;
         if (connect)
             this.connected_promise = this.client_client.connect();
         else
             this.connected_promise = Promise.resolve("told not to connect");
+        this.jsonParseReviver = jsonParseReviver 
+        this.jsonStringifyReplacer = jsonStringifyReplacer 
 
         const errorOrCloseCB = (...args: any[]) => {
             console.log(`Error in RedisClient: ${name}.`, "\r\n", ...args);

--- a/src/adapters/redis.ts
+++ b/src/adapters/redis.ts
@@ -1,5 +1,5 @@
 import IORedis, {Redis, RedisOptions} from "ioredis";
-import { CacheKey, CacheProvider, TReplacerFunction, TReviverFunction } from "./base";
+import { CacheKey, CacheProvider, SerializationOptions } from "./base";
 
 export class RedisCacheProvider implements CacheProvider<string> {
 
@@ -8,22 +8,29 @@ export class RedisCacheProvider implements CacheProvider<string> {
     }
 
     readonly storesAsObj: boolean = false
-    readonly jsonParseReviver: TReviverFunction | undefined
-    readonly jsonStringifyReplacer: TReplacerFunction | undefined
+    private readonly _serializationOptions: SerializationOptions
+
+    get serializationOptions(): SerializationOptions {
+        return this._serializationOptions;
+    }
 
     private readonly client_client: Redis;
     private readonly connected_promise: any;
     private readonly connect: boolean;
 
-    constructor(name: string, options: RedisOptions, connect: boolean = true, jsonParseReviver?: TReviverFunction, jsonStringifyReplacer?: TReplacerFunction) {
+    constructor(
+        name: string, 
+        options: RedisOptions, 
+        connect: boolean = true, 
+        serializationOptions: SerializationOptions = {}
+    ) {
         this.client_client = new IORedis(options);
         this.connect = connect;
         if (connect)
             this.connected_promise = this.client_client.connect();
         else
             this.connected_promise = Promise.resolve("told not to connect");
-        this.jsonParseReviver = jsonParseReviver 
-        this.jsonStringifyReplacer = jsonStringifyReplacer 
+        this._serializationOptions = serializationOptions;
 
         const errorOrCloseCB = (...args: any[]) => {
             console.log(`Error in RedisClient: ${name}.`, "\r\n", ...args);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,35 @@
 # yarn lockfile v1
 
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@ioredis/commands@^1.1.1":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
   integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
+
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
+
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
+  integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@mongodb-js/saslprep@^1.1.5":
   version "1.1.7"
@@ -13,6 +38,31 @@
   integrity sha512-dCHW/oEX0KJ4NjDULBo3JiOaK5+6axtpBbS+ao2ZInoAL9/YRQLhXzSNAFz7hP4nzLkIqsfYAK/PDE3+XHny0Q==
   dependencies:
     sparse-bitfield "^3.0.3"
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
+  integrity sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
+"@types/lodash@^4.17.16":
+  version "4.17.16"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.16.tgz#94ae78fab4a38d73086e962d0b65c30d816bfb0a"
+  integrity sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==
 
 "@types/node@^20.14.9":
   version "20.14.9"
@@ -38,6 +88,23 @@
   dependencies:
     "@types/webidl-conversions" "*"
 
+acorn-walk@^8.1.1:
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.4.tgz#794dd169c3977edf4ba4ea47583587c5866236b7"
+  integrity sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==
+  dependencies:
+    acorn "^8.11.0"
+
+acorn@^8.11.0, acorn@^8.4.1:
+  version "8.14.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.1.tgz#721d5dc10f7d5b5609a891773d47731796935dfb"
+  integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 bson@^6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/bson/-/bson-6.7.0.tgz#51973b132cdc424c8372fda3cb43e3e3e2ae2227"
@@ -47,6 +114,11 @@ cluster-key-slot@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
   integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 debug@4.x, debug@^4.3.4:
   version "4.3.5"
@@ -59,6 +131,11 @@ denque@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
   integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 ioredis@^5.4.1:
   version "5.4.1"
@@ -89,6 +166,16 @@ lodash.isarguments@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
   integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 memory-pager@^1.0.2:
   version "1.5.0"
@@ -193,6 +280,25 @@ tr46@^4.1.1:
   dependencies:
     punycode "^2.3.0"
 
+ts-node@^10.9.2:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 typescript@^5.5.2:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
@@ -202,6 +308,11 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 webidl-conversions@^7.0.0:
   version "7.0.0"
@@ -215,3 +326,8 @@ whatwg-url@^13.0.0:
   dependencies:
     tr46 "^4.1.1"
     webidl-conversions "^7.0.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
This commit updates the Memoize class in the Memoize.ts file to support JSON parsing and stringifying. It adds the TReplacerFunction and TReviverFunction types to the CacheProvider interface in the base.ts file. The MemoryCacheProvider in the memory.ts file now sets the jsonParseReviver and jsonStringifyReplacer properties to undefined since it directly stores objects. The RedisCacheProvider in the redis.ts file also sets these properties to undefined. This change improves the flexibility and functionality of the Memoize class.